### PR TITLE
cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 project(shm)
 set( version 1.1 )
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
-
+##
+# for submodules, this needs to be reset to avoid
+# preferencing parent module paths.
+##
+set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 find_package( NUMA )
 find_package( Threads )
 find_package( LIBRT )

--- a/shm.pc.in
+++ b/shm.pc.in
@@ -7,6 +7,6 @@ Description: C++ wrappers for POSIX shared memory
 Version: 1.0 
 Requires: 
 Conflicts: 
-Libs:  -L${libdir} @CMAKE_RT_LDFLAGS@ @CMAKE_NUMA_LDFLAGS@ @CMAKE_RT_LIB@ @CMAKE_NUMA_LIB@
+Libs:  -L${libdir} -lshm @CMAKE_RT_LDFLAGS@ @CMAKE_NUMA_LDFLAGS@ @CMAKE_RT_LIB@ @CMAKE_NUMA_LIB@
 Libs.private: 
 Cflags: -I${includedir}


### PR DESCRIPTION
fix module path for submodule includes, needs to be reset when entering submodule to prevent conflicts. 