### PR TITLE
updates to findnuma.cmake file

### DIFF
--- a/cmake/FindNUMA.cmake
+++ b/cmake/FindNUMA.cmake
@@ -1,4 +1,52 @@
-if( CMAKE_HOST_UNIX AND NOT WIN32 )
+#if( CMAKE_HOST_UNIX AND NOT WIN32 )
+#find_library( NUMA_LIBRARY
+#              NAMES numa
+#              PATHS
+#              ${CMAKE_LIBRARY_PATH}
+#              $ENV{NUMA_PATH}/lib
+#              /usr/lib
+#              /usr/local/lib
+#              /opt/local/lib )
+#
+#find_path(  NUMA_INCLUDE_DIRS
+#            NAME numaif.h
+#            PATHS
+#              ${CMAKE_LIBRARY_PATH}$
+#              $ENV{NUMA_PATH}/lib$
+#              /usr/lib$
+#              /usr/local/lib$
+#              /opt/local/lib )
+#
+#if( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
+#    get_filename_component( NUMA_LIBRARY ${NUMA_LIBRARY} DIRECTORY )
+#    set( CMAKE_NUMA_LDFLAGS "-L${NUMA_LIBRARY}" )
+#    set( CMAKE_NUMA_LIB "-lnuma" )
+#    add_definitions( "-DPLATFORM_HAS_NUMA=1" )
+#    include_directories( ${NUMA_INCLUDE_DIRS} )
+#else( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
+###
+## get machine type
+###
+#    execute_process( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+#    execute_process( COMMAND ${PROJECT_SOURCE_DIR}/scripts/findnodes.pl
+#                     COMMAND tr -d '\n' 
+#                     OUTPUT_VARIABLE HASNUMA )
+#    if( HASNUMA EQUAL 0 )
+#        ## no NUMA
+#        message( STATUS "no NUMA needed" )
+#        add_definitions( "-DPLATFORM_HAS_NUMA=0" )
+#    else( HASNUMA EQUAL 0 )
+#        ## needs NUMA but we don't have it
+#        message( FATAL_ERROR "You are compiling on a NUMA system, you must install libnuma" )
+#    endif( HASNUMA EQUAL 0 )
+#endif( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
+#
+#endif()
+
+##
+# at this point we just need a warning
+##
+if( CMAKE_HOST_UNIX AND NOT WIN32)
 find_library( NUMA_LIBRARY
               NAMES numa
               PATHS
@@ -18,9 +66,7 @@ find_path(  NUMA_INCLUDE_DIRS
               /opt/local/lib )
 
 if( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
-    get_filename_component( NUMA_LIBRARY ${NUMA_LIBRARY} DIRECTORY )
-    set( CMAKE_NUMA_LDFLAGS "-L${NUMA_LIBRARY}" )
-    set( CMAKE_NUMA_LIB "-lnuma" )
+    set( CMAKE_NUMA_LIBS ${NUMA_LIBRARY} )
     add_definitions( "-DPLATFORM_HAS_NUMA=1" )
     include_directories( ${NUMA_INCLUDE_DIRS} )
 else( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
@@ -28,7 +74,7 @@ else( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
 # get machine type
 ##
     execute_process( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
-    execute_process( COMMAND ${PROJECT_SOURCE_DIR}/scripts/findnodes.pl
+    execute_process( COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/findnodes.pl
                      COMMAND tr -d '\n' 
                      OUTPUT_VARIABLE HASNUMA )
     if( HASNUMA EQUAL 0 )
@@ -42,3 +88,4 @@ else( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
 endif( NUMA_LIBRARY AND NUMA_INCLUDE_DIRS )
 
 endif()
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,5 +2,6 @@ set( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 
 add_library( shm shm.cpp )
+target_link_libraries( shm ${CMAKE_NUMA_LIBS} )
 install( TARGETS shm
          ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )


### PR DESCRIPTION
Fix of ```usr/bin/ld: shm.cpp:(.text+0x18f8): undefined reference to `numa_num_configured_nodes'```

where on NUMA systems the flag was set incorrectly and therefore no NUMA libs were included and no NUMA code from the library was added. As soon as the flag is correctly set then linker errors occur. This pull request fixes the NUMA flag and NUMA lib includes. 